### PR TITLE
Updated to be comma separated

### DIFF
--- a/Raffler.cs
+++ b/Raffler.cs
@@ -23,7 +23,7 @@ namespace MeetRaffle
             {
                 var csv = new CsvReader(reader, new CsvConfiguration {
                     HasHeaderRecord = true,
-                    Delimiter ="\t",
+                    Delimiter =","
                 });
                 csv.Configuration.RegisterClassMap<AttendeeMap>();
 


### PR DESCRIPTION
Meet Up have altered their download file to be a comma separated .xls (it was previously tab separated). Here's a change to the separator format, but still requires file to be converted from .xls to .csv.
